### PR TITLE
Fix task timer

### DIFF
--- a/src/Core/Managed/Shared/Extensibility/Implementation/TaskTimer.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/TaskTimer.cs
@@ -71,7 +71,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                         CancelAndDispose(Interlocked.CompareExchange(ref this.tokenSource, null, newTokenSource));
                         try
                         {
-                            await elapsed(); 
+                            await elapsed().ConfigureAwait(false);
                         }
                         catch (Exception exception)
                         {


### PR DESCRIPTION
TaskTimer throws NullReferenceException in MoveNext:
Microsoft.ApplicationInsights.Extensibility.Implementation.TaskTimer.<>c__DisplayClass1.<<Start>b__0>d__3.MoveNext()
That happens when thread tries to return to the thread that is already gone.